### PR TITLE
Add option to use mp3 tags for titles sent to voting endpoint.

### DIFF
--- a/scripts/fpp_install.sh
+++ b/scripts/fpp_install.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -x
 
-sudo apt-get update && sudo apt-get install -y python3-requests python3-crontab;
+sudo apt-get update && sudo apt-get install -y python3-requests python3-crontab python3-mutagen;

--- a/scripts/fpp_update.sh
+++ b/scripts/fpp_update.sh
@@ -13,6 +13,11 @@ if ! dpkg -s python3-crontab >/dev/null 2>&1; then
     missing_packages+=" python3-crontab"
 fi
 
+# Check for python3-mutagen
+if ! dpkg -s python3-mutagen >/dev/null 2>&1; then
+    missing_packages+=" python3-mutagen"
+fi
+
 if [ -n "$missing_packages" ]; then
     sudo apt-get update
     sudo apt-get install -y$missing_packages

--- a/scripts/vote-service.py
+++ b/scripts/vote-service.py
@@ -9,6 +9,7 @@ import re
 import sqlite3
 from crontab import CronTab
 from contextlib import closing
+from mutagen.easyid3 import EasyID3
 
 
 
@@ -114,7 +115,24 @@ def load_songs(playlist_to_load):
 
         title = ''
         logging.info('title pref {}'.format(title_pref))
-        if title_pref is None or title_pref == 'sequenceName':
+        if title_pref == 'mp3Tag':
+            logging.info('use mp3 tags')
+            if 'mediaName' in song:
+                try:
+                    audio = EasyID3('/home/fpp/media/music/' + song['mediaName'])
+                    title = audio['title'][0] + ' - ' + audio['artist'][0]
+                except Exception as e:
+                    logging.warning("Could not read MP3 tags for {}: {}".format(song['mediaName'], e))
+                    if 'sequenceName' in song:
+                        title = str(song['sequenceName'])
+                    else:
+                        title = str(song['mediaName'])
+            else:
+                if 'sequenceName' in song:
+                    title = str(song['sequenceName'])
+                else:
+                    title = 'Unknown'
+        elif title_pref is None or title_pref == 'sequenceName':
             logging.info('use sequence names')
             if 'sequenceName' in song:
                 title = str(song['sequenceName'])
@@ -593,4 +611,3 @@ while True:
     time.sleep(1)
     get_status()
     status_iteration += 1
-

--- a/vote.php
+++ b/vote.php
@@ -501,6 +501,10 @@ if (isset($_POST['loadSettings'])) {
                     <input type="radio" class="custom-control-input" name="votingTitlePreference" id="audioName" value="audioName">
                     <label class="custom-control-label" for="audioName">Audio Name</label>
                 </div>
+                <div class="custom-control custom-radio">
+                    <input type="radio" class="custom-control-input" name="votingTitlePreference" id="mp3Tag" value="mp3Tag">
+                    <label class="custom-control-label" for="mp3Tag">MP3 Tag</label>
+                </div>
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
This adds an option to pull the titles displayed on the voting page from the mp3 tags in the media directly.

My sequence names and media file names are a mess. My mp3 files have tags set up correctly though because the RDS plugin for my FM transmitter pulls song names from the mp3 files directly.